### PR TITLE
Laravel 12 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=SPYLWZ8Y5E4
 
 ## Requirements
 
-* Laravel: 9.0 and up
-* PHP: 8.1 and newer
+* Laravel: 11.0 and up
+* PHP: 8.2 and newer
 
 #### Database schema
 

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,8 @@
     }
   ],
   "require": {
-    "php": ">=8.1",
-    "laravel/framework": "^9.0 || ^10.0 || ^11.0"
+    "php": "^8.2",
+    "laravel/framework": "^11.0 || ^12.0"
   },
   "require-dev": {
     "laravel/pint": "^1.6"


### PR DESCRIPTION
This PR alters the support Laravel versions to 11 and 12 to align with the [Laravel Support Policy](https://laravel.com/docs/master/releases#support-policy) this means the minimum PHP version now supported is 8.2.